### PR TITLE
Improve contrast of the highlight ansi colors

### DIFF
--- a/app/styles/app/vars.sass
+++ b/app/styles/app/vars.sass
@@ -43,11 +43,11 @@ $color-bg-log-fold-highlight: #777
 $ansi-black: #4E4E4E
 $ansi-black-bold: #7C7C7C
 $ansi-red: #FF6C60
-$ansi-red-bold: #FFB6B0
+$ansi-red-bold: #FF9B93
 $ansi-green: #00AA00
-$ansi-green-bold: #CEFFAB
+$ansi-green-bold: #B1FD79
 $ansi-yellow: #FFFFB6
-$ansi-yellow-bold: #FFFFCB
+$ansi-yellow-bold: #FFFF91
 $ansi-blue: #96CBFE
 $ansi-blue-bold: #B5DCFE
 $ansi-magenta: #FF73FD


### PR DESCRIPTION
The contrast of the green, red and yellow highlight colors was too low.

Before:
![screen shot 2016-04-14 at 11 53 59](https://cloud.githubusercontent.com/assets/1243901/14524240/b426838a-0237-11e6-9145-90f5418782a1.png)

After:
![screen shot 2016-04-14 at 11 53 44](https://cloud.githubusercontent.com/assets/1243901/14524229/ad9b9794-0237-11e6-9ab3-0c7a8ff61e7e.png)
